### PR TITLE
Fixed Broken Handbook Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SAFE Labs Handbook
 
-For the most readable version of this handbook, visit the [SAFE Labs Website](https://safelabs.info/home/safe-labs-handbook/).<br/>
+For the most readable version of this handbook, visit the [SAFE Labs Website](https://safelabs.info/handbook/).<br/>
 
 ---
 


### PR DESCRIPTION
### Overview
- Updated README.md for SAFE Labs.

### In-depth Details
- Hi, I just happened to be doing some research, and I found this repo.
- I realized the link to the SAFE Labs Handbook on the [website](https://safelabs.info/) is broken.
- The correct link (as of 8/12/26) is as follows: [https://safelabs.info/handbook/](https://safelabs.info/handbook/).